### PR TITLE
Updated alt text for logo in Header component

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -65,7 +65,7 @@ class Header extends Component<IProps> {
               <img
                 src={Logo}
                 className="logo"
-                alt="Sutton Information Hub" />
+                alt="Sutton Information Hub Logo - Mother in a hi-jab with their son, a teenage girl using a guide dog and an older person using a walking stick" />
             </RouterLink>
           </figure>
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1853/update-alt-text-on-logo

### Development checklist
N/A

### Release checklist
N/A

### Notes
I have left in the text "Sutton Information Hub Logo" to describe the text in the logo and appended the rest of this text to this alt tag
