### PR TITLE
Added sort by order field for landing and information pages

### DIFF
--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -20,7 +20,7 @@ export default class PageStore {
     try {
       const pagesData = await axios.get(`${apiBase}/pages?filter[page_type]=landing`);
       runInAction(() => {
-        this.pages = get(pagesData, 'data.data');
+        this.pages = get(pagesData, 'data.data').sort((a: { order: number; }, b: { order: number; }) => a.order - b.order);
       });
     } catch (error) {
       this.loading = false;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ import { IconName } from '@fortawesome/fontawesome-svg-core';
 export interface IPage {
   id: string;
   enabled: boolean;
+  order: number; 
   page_type: string;
   title: string;
   image: string;

--- a/src/views/Page/InformationPage.tsx
+++ b/src/views/Page/InformationPage.tsx
@@ -68,7 +68,9 @@ function InformationPage(props: any) {
               <h2 className="information-page__sub-heading">Other pages in this section</h2>
             </div>
             <div className="flex-col flex-col--12 information-page__pages">
-              {props.content.children.filter((child: IPage) => child.enabled).map((page: { id: string; title: string; icon: IconName; }) => {
+              {props.content.children.filter((child: IPage) => child.enabled)
+                .sort((a: { order: number; }, b: { order: number; }) => a.order - b.order)
+                .map((page: { id: string; title: string; icon: IconName; }) => {
                 return (
                   <ButtonLink
                     href={'/' + page.id}

--- a/src/views/Page/LandingPage.tsx
+++ b/src/views/Page/LandingPage.tsx
@@ -90,7 +90,10 @@ function LandingPage(props: any) {
               )}
             </div>
             <div className="flex-col flex-col--12 landing-page__pages">
-              {props.content.children.filter((child: IPage) => child.enabled).map((page: { id: string; title: string; }) => {
+              {console.log(props.content.children)}
+              {props.content.children.filter((child: IPage) => child.enabled)
+                .sort((a: { order: number; }, b: { order: number; }) => a.order - b.order)
+                .map((page: { id: string; title: string; }) => {
                 return (
                   <ButtonLink
                     href={'/' + page.id}


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1849/the-order-of-pages-under-landing-and-parent-pages-on-the-admin-area-is-not-reflected-on-the-front-end

### Development checklist
N/A

### Release checklist
N/A

### Notes
N/A
