### PR TITLE
Output tags in search result card and service page

### DIFF
--- a/src/components/SearchResultCard/SearchResultCard.tsx
+++ b/src/components/SearchResultCard/SearchResultCard.tsx
@@ -116,6 +116,15 @@ class SearchResultCard extends React.Component<IProps> {
 
                 {result.is_free ? 'Free' : 'Cost'}
               </div>
+              {result.tags.map(tag => (
+                <div
+                  className={cx('search-result-card__tag', `search-result-card__tag--tag`)}
+                  aria-label={`This ${result.type} is tagged with ${tag}`}
+                >
+                  <FontAwesomeIcon icon="tag" className="search-result-card__tag--icon" />
+                  {tag}
+                </div>
+              ))}
             </div>
             {!!locations.length && (
               <div

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -117,6 +117,7 @@ export interface IService {
   slug: string;
   social_medias: [];
   status: string;
+  tags: [];
   testimonial: null | string;
   type: string;
   updated_at: string;

--- a/src/views/Service/Service.scss
+++ b/src/views/Service/Service.scss
@@ -57,6 +57,28 @@
   }
 }
 
+.service__header__tags {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin: space(8) 0;
+}
+
+.service__header__tag {
+  margin-right: space(16);
+  margin-bottom: space(16);
+  padding: space(4) space(8);
+  @include body-s;
+  font-weight: 600;
+  background-color: $casablanca;
+  color: $black;
+  border-radius: 4px;
+
+  svg {
+    margin-right: space(4)
+  }
+}
+
 .service__header__label {
   @include heading-xs;
   margin-bottom: space(8);

--- a/src/views/Service/Service.tsx
+++ b/src/views/Service/Service.tsx
@@ -231,6 +231,19 @@ class Service extends Component<IProps> {
                   . View their organisation details and other listed services.
                 </p>
               )}
+              <div className="service__header__tags">
+                {map(service.tags, (tag: any) => (
+                  <Fragment key={tag.id}>
+                    <span
+                      className="service__header__tag"
+                      aria-label={`This ${service.type} is tagged with ${tag}`}
+                    >
+                      <FontAwesomeIcon icon="tag" className="service__header__tag--icon" />
+                      {tag.label}
+                    </span>
+                  </Fragment>
+                ))}
+              </div>
               <div className="service__header__actions">
                 {organisation && organisation.slug && (
                   <LinkButton


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1448/add-ability-for-services-to-be-tagged-with-business-unit-labels

### Development checklist
N/A

### Release checklist
N/A

### Notes
N/A
