### PR TITLE
Added fix for search result card width because of title word break

### DIFF
--- a/src/components/SearchResultCard/SearchResultCard.scss
+++ b/src/components/SearchResultCard/SearchResultCard.scss
@@ -28,6 +28,7 @@
 .search-result-card__title {
   flex: 1;
   padding-right: space(16);
+  word-break: break-word;
 }
 
 .search-result-card__organisation {


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1855/search-results-grid-width-not-consistent

N/A

### Development checklist
N/A

### Release checklist
N/A

### Notes
N/A
