### PR TITLE
Output CQC Widget on service inner page

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/webpack-env": "^1.16.3",
     "axios": "^0.25.0",
     "classnames": "^2.3.1",
+    "dangerously-set-html-content": "^1.0.9",
     "dompurify": "^2.3.5",
     "dotenv": "^14.2.0",
     "html-react-parser": "^1.4.6",

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -93,6 +93,7 @@ export interface IService {
   contact_email: string;
   contact_name: string;
   contact_phone: string;
+  cqc_location_id: string;
   eligibility_types: IEligibility;
   created_at: string;
   description: string;

--- a/src/views/Service/Service.tsx
+++ b/src/views/Service/Service.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { inject, observer } from 'mobx-react';
 import { RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';
+import InnerHTML from 'dangerously-set-html-content'
 import get from 'lodash/get';
 import map from 'lodash/map';
 import find from 'lodash/find';
@@ -178,6 +179,10 @@ class Service extends Component<IProps> {
     if (service.status === 'inactive') {
       return <ServiceDisabled />;
     }
+
+    const cqcWidget = (locationId: string) => {
+      return `<script type="text/javascript" src="https://www.cqc.org.uk/sites/all/modules/custom/cqc_widget/widget.js?data-id=${locationId}&data-host=www.cqc.org.uk&type=location"></script>`;
+    };
 
     return (
       <main className="service">
@@ -543,6 +548,12 @@ class Service extends Component<IProps> {
                     </div>
                   )}
                 </div>
+                {(service.cqc_location_id && service.cqc_location_id.match(/^\d\-\d+$/)) &&
+                  <div className="service__section">
+                    <h2 className="service__heading">This {service.type}'s CQC Rating</h2>
+                    <InnerHTML html={cqcWidget(service.cqc_location_id)} />
+                  </div>
+                }
                 <div className="service__section">
                   <ShareCard serviceStore={serviceStore} />
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3424,6 +3424,11 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+dangerously-set-html-content@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/dangerously-set-html-content/-/dangerously-set-html-content-1.0.9.tgz#d876deda1ec9ef4e62b21847f6dd6bc39d03a2cb"
+  integrity sha512-nnXstBbPIaE+HEy6FbYpi14wIhIcPHkzNDCprpsrhwvyYtZE1Z44qYcbx8nlYpNdbYeW7x4Bkhx784Ud5QPa+A==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1876/embed-cqc-widget-on-service-page

### Development checklist
N/A

### Release checklist
It was discussed with @AyupMike that using the third party package here which outputs third party javascript library widget scripts is a potential XSS risk and too cover this as much as possible a regex check has been done on the returned string from the API which is the same as the regex used in the admin panel.

### Notes
N/A
