### PR TITLE
2354: Update service/organisation logos so that they are contained better

### DIFF
--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -14,5 +14,6 @@ $periwinkle-gray: #C9D9EB;
 $pippin: #FFE5DC;
 $link-water: #F4F8FC;
 $botticelli: #D5E2ED;
+$lavender: #ddebfa;
 
 $error: red;

--- a/src/views/Service/Service.scss
+++ b/src/views/Service/Service.scss
@@ -35,8 +35,7 @@
   width: 154px;
   height: 154px;
   margin: 0 space(40) space(40) 0;
-  border-radius: 40px;
-  box-sizing: content-box;
+  border-radius: 20px;
   overflow: hidden;
 
   @include for-tablet-landscape-down {
@@ -53,7 +52,9 @@
   img {
     height: 100%;
     width: 100%;
-    object-fit: cover;
+    object-fit: contain;
+    padding: 0.5rem;
+    background-color: $lavender;
   }
 }
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2354/update-service-organisation-logos-so-that-they-are-contained-better

fixed image scaling issue for service logo and added background colour for cases where logo text is white

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
