### PR TITLE
2470: search results hide information page image

### DIFF
--- a/src/components/Button/ButtonWithParent.tsx
+++ b/src/components/Button/ButtonWithParent.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { IconName } from '@fortawesome/fontawesome-common-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import cx from 'classnames';
 
-import { getImg } from '../../utils/utils';
+import { getResolvedImg } from '../../utils/utils';
 
 import './Button.scss';
 
@@ -23,6 +23,7 @@ interface IProps {
     title: string;
     slug: string;
     id: string | null;
+    image: string;
   };
 }
 
@@ -34,37 +35,44 @@ const ButtonLink: React.FunctionComponent<IProps> = ({
   target = '_self',
   excerpt,
   parent,
-}) => (
-  <div
-    className={cx('button button__excerpt__parent', {
-      button__excerpt: excerpt && excerpt.isExcerpt,
-    })}
-  >
-    <a
-      href={href}
-      target={target}
-      className="flex__wrapper h4 info__link"
-      rel={target === '_blank' ? 'noopener nofollow noreferrer' : undefined}
-    >
-      {image && <img src={image} alt={text} className="button__image" />}
-      <div className="button__excerpt__title">{text}</div>
-      {icon && <FontAwesomeIcon icon={icon} className={cx('button__icon')} />}
-    </a>
+}) => {
+  const [parentImage, setParentImage] = useState<string | null>(null);
 
-    {parent && (
-      <div className="flex__wrapper parent__link">
-        <p>
-          Part of
-          <Link to={`/pages/${parent.slug}`}> {parent.title}</Link>
-        </p>
-        <img
-          alt={parent.title ? parent.title : ''}
-          className="image"
-          src={getImg(parent.id as string, 120)}
-        />
-      </div>
-    )}
-  </div>
-);
+  useEffect(() => {
+    getResolvedImg(parent?.id as string, 120).then((path) => setParentImage(path as string));
+  }, [parent]);
+
+  return (
+    <div
+      className={cx('button button__excerpt__parent', {
+        button__excerpt: excerpt && excerpt.isExcerpt,
+      })}
+    >
+      <a
+        href={href}
+        target={target}
+        className="flex__wrapper h4 info__link"
+        rel={target === '_blank' ? 'noopener nofollow noreferrer' : undefined}
+      >
+        {image && <img src={image} alt={text} className="button__image" />}
+        <div className="button__excerpt__title">{text}</div>
+        {icon && <FontAwesomeIcon icon={icon} className={cx('button__icon')} />}
+      </a>
+
+      {parent && (
+        <div className="flex__wrapper parent__link">
+          <p>
+            Part of
+            <Link to={`/pages/${parent.slug}`}> {parent.title}</Link>
+          </p>
+
+          {parentImage && (
+            <img alt={parent.title ? parent.title : ''} className="image" src={parentImage} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default ButtonLink;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,16 +15,46 @@ export const removeQuotesRegex = new RegExp(/^["']|["']$|["]/, 'g');
 
 export const capitalise = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
 
+/**
+ * Used to get the image path where there is a fallback image
+ * @param pageId
+ * @param max_dimension
+ * @returns
+ */
 export const getImg = (pageId: string, max_dimension = 900) =>
   `${apiBase}/pages/${pageId}/image.png?max_dimension=${max_dimension}`;
 
+/**
+ * Used to get image path, where it first checks whether the image exists before returning the path
+ * @param pageId
+ * @param max_dimension
+ * @returns
+ */
+export const getResolvedImg = (pageId: string, max_dimension = 900) =>
+  new Promise((resolve) => {
+    const path = `${apiBase}/pages/${pageId}/image.png?max_dimension=${max_dimension}`;
+    const http = new XMLHttpRequest();
+
+    http.open('HEAD', path, false);
+    http.send();
+
+    http.status !== 404 ? resolve(path) : resolve(null);
+  });
 
 export const getServiceImg = (service: IService) => {
   if (service.has_logo) {
     return `${apiBase}/services/${service.id}/logo.png?`;
   } else {
-    if (get(service, 'organisation_id')) return `${apiBase}/organisations/${get(service, 'organisation_id')}/logo.png?v=${get(service, 'organisation_id')}`;
-    if (get(service, 'organisation.id')) return `${apiBase}/organisations/${get(service, 'organisation.id')}/logo.png?v=${get(service,'organisation.id')}`;
-    return ''
+    if (get(service, 'organisation_id'))
+      return `${apiBase}/organisations/${get(service, 'organisation_id')}/logo.png?v=${get(
+        service,
+        'organisation_id'
+      )}`;
+    if (get(service, 'organisation.id'))
+      return `${apiBase}/organisations/${get(service, 'organisation.id')}/logo.png?v=${get(
+        service,
+        'organisation.id'
+      )}`;
+    return '';
   }
 };


### PR DESCRIPTION
### Summary
Added a method to check if image exists before displaying it. 

https://app.shortcut.com/helpyourselfsutton/story/2470/search-results-hide-information-page-image-if-none-supplied

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
