### PR TITLE
2473: displaying last updated text on landing page regardless of other side…

### DIFF
--- a/src/views/Page/LandingPage.tsx
+++ b/src/views/Page/LandingPage.tsx
@@ -68,15 +68,16 @@ function LandingPage(props: any) {
               />
             </div>
           )}
-          {props.content.content.about.content[1] && (
-            <div className="flex-col flex-col--4">
+
+          <div className="flex-col flex-col--4">
+            {props.content.content.about.content[1] && (
               <ReactMarkdown
                 children={props.content.content.about.content[1].value}
                 className="landing-page__content markdown"
               />
-              <LastUpdatedAt time={props.content.updated_at} />
-            </div>
-          )}
+            )}
+            <LastUpdatedAt time={props.content.updated_at} />
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
…bar content

### Summary
displaying last updated text on landing page regardless of other sidebar content

https://app.shortcut.com/helpyourselfsutton/story/2473/last-updated-timestamp-gets-hidden-when-no-content-supplied-in-the-second-about-content-box

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
