### PR TITLE
2479: styling of ordered lists with the start attribute

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -353,6 +353,27 @@ blockquote {
         }
       }
     }
+
+    ul,
+    ol {
+      list-style-position: outside;
+      margin: 2rem;
+      @include for-phone-only {
+        margin: 1rem;
+      }
+
+      li {
+        margin-top: 0;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+
+        &::marker {
+          @include body-l;
+        }
+      }
+    }
   }
 
   a {
@@ -380,47 +401,17 @@ blockquote {
     }
   }
 
-  ol > li::marker {
-    display: inline-block;
-    @include body-l;
-    line-height: 2.25rem;
-  }
-
-  ol > li p {
-    display: inline-block;
-    margin-left: 0.5rem;
-  }
-}
-
-// uniform the styling for ul's and ol's in side a markup component
-.information-page__content.markdown {
-  ul,
-  ol {
-    padding: 2rem;
-    @include for-phone-only {
-      padding: 1rem;
-    }
-  }
-  ol {
-    counter-reset: counterVar;
-    display: table;
-  }
-
   ol > li {
-    counter-increment: counterVar;
-    display: flex;
     margin-bottom: 1rem;
-  }
+    padding-left: 0.5rem;
 
-  ol > li {
     p {
-      margin-left: 1rem;
+      display: inline;
     }
 
-    &::before {
-      content: counter(counterVar) '.';
-      display: table;
-      @include body-xm;
+    &::marker {
+      display: list-item;
+      @include body-m;
     }
   }
 }


### PR DESCRIPTION
### Summary
fixing ordered list numbering to honor start attribute

https://app.shortcut.com/helpyourselfsutton/story/2479/styling-of-ordered-lists-with-the-start-attribute

### Development checklist
- [ ] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
