### PR TITLE
Changed hounslow ref to sutton in lambda

### DIFF
--- a/aws/lambda.yml
+++ b/aws/lambda.yml
@@ -407,7 +407,7 @@ Resources:
 
             const metaDesc = prepareDescription(rawPageContent);
 
-            const metaTitle = _get(data, 'name', defaultTitle).concat(' in Hounslow');
+            const metaTitle = _get(data, 'name', defaultTitle).concat(' in Sutton');
 
             let metas = [];
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2782/hotfix-open-graph-data-referencing-in-hounslow

- Changed a reference to Hounslow to Sutton in the SEO function in lambda.yml

### Development checklist
- [x] The code has been linted `yarn lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
