### PR TITLE
only load landing page parent image if available

### DIFF
--- a/src/components/Button/ButtonWithParent.tsx
+++ b/src/components/Button/ButtonWithParent.tsx
@@ -39,7 +39,7 @@ const ButtonLink: React.FunctionComponent<IProps> = ({
   const [parentImage, setParentImage] = useState<string | null>(null);
 
   useEffect(() => {
-    getResolvedImg(parent?.id as string, 120).then((path) => setParentImage(path as string));
+    if (parent?.image) getResolvedImg(parent?.id as string, 120).then((path) => setParentImage(path as string));
   }, [parent]);
 
   return (
@@ -66,7 +66,7 @@ const ButtonLink: React.FunctionComponent<IProps> = ({
             <Link to={`/pages/${parent.slug}`}> {parent.title}</Link>
           </p>
 
-          {parentImage && (
+          {parent?.image && parentImage && (
             <img alt={parent.title ? parent.title : ''} className="image" src={parentImage} />
           )}
         </div>


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3634/sutton-images-not-loading-on-search-resutls-page-for-landing-pages

Write a brief short summary about the PR here.

### Development checklist

- [ ] The code has been linted `yarn lint --fix`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
